### PR TITLE
Add docs/README.md with overview and links to OctoAcme project management process documents

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,28 @@
+# OctoAcme Project Management Docs
+
+Welcome to OctoAcme’s central hub for project management processes. This README gives new contributors and project participants a high-level summary of how we run projects—from initiation through delivery, release, and continuous improvement—and links to all detailed process docs.
+
+## Overview of Project Management Processes
+
+OctoAcme delivers projects using a structured, iterative approach focused on maximizing customer value, transparency, and efficient cross-functional collaboration. Projects progress through Initiation, Planning, Execution & Tracking, Release & Deployment, Closure, and Continuous Improvement. Key workflows standardize how teams move from validating business need, scoping work, managing execution, tracking risks, communicating status, releasing value, and reflecting for improvement.
+
+Roles are clearly defined. Project Managers coordinate schedules, risks, and communications, enabling transparency and consistent reporting. Product Managers own the product vision and prioritize outcomes. Developers deliver reliable, well-tested code and collaborate through daily standups, code reviews, and technical discussions, while QA specialists partner across the lifecycle to ensure quality and validate acceptance criteria. Stakeholders provide input and approvals throughout.
+
+Communication is a core strength, with daily standups, weekly delivery syncs, monthly stakeholder briefings, and escalation paths that clarify issue management. Status, risks, and milestones are visible through dashboards, templates, and regular documentation updates. Retrospectives follow each milestone, driving a continuous feedback loop.
+
+Quality assurance is deeply integrated: automated tests, manual QA, and security checks are part of CI/CD pipelines, with reporting and metrics feeding into improvement actions. Releases and deployments follow checklists, are announced to stakeholders, and include rollback and incident playbooks to manage risk and maintain reliability.
+
+## Linked Docs
+
+- [Project Management Overview](octoacme-project-management-overview.md)
+- [Project Initiation Guide](octoacme-project-initiation.md)
+- [Project Planning](octoacme-project-planning.md)
+- [Execution & Tracking](octoacme-execution-and-tracking.md)
+- [Risk Management & Communication](octoacme-risks-and-communication.md)
+- [Release & Deployment Guide](octoacme-release-and-deployment.md)
+- [Retrospective & Continuous Improvement](octoacme-retrospective-and-continuous-improvement.md)
+- [Roles and Personas](octoacme-roles-and-personas.md)
+
+---
+
+**For detailed roles, checklists, and templates, see each linked file in this folder.**


### PR DESCRIPTION
Adds a README to the docs/ folder as requested in [issue #2](https://github.com/sunnery7/skills-scale-institutional-knowledge-using-copilot-spaces/issues/2).
README summarizes OctoAcme’s project management workflows, key roles, communication strategies, and QA practices, with direct links to all docs for easier navigation and onboarding.
Closes #2.